### PR TITLE
fix: Prevent premature MCP session deletion

### DIFF
--- a/src/app/httpServer.ts
+++ b/src/app/httpServer.ts
@@ -85,13 +85,6 @@ export function setupAppServer(
       } else {
         const session = activeSessions.get(sessionId);
         if (session) {
-          res.on('close', () => {
-            logger.info(
-              { event: 'sse_connection_closed', sessionId },
-              'SSE connection closed, cleaning up session',
-            );
-            onSessionClosed(sessionId);
-          });
           await session.transport.handleRequest(req, res, req.body);
         } else {
           res.status(404).json({


### PR DESCRIPTION
This PR fixes a bug where MCP sessions were being prematurely deleted, causing 'Session not found' errors. The 'close' event handler on the response object was removed to prevent this.