### PR TITLE
fix: solve_problem incorrectly returns optimal status for infeasible problems

### DIFF
--- a/src/connectors/remip/ReMIPClient.ts
+++ b/src/connectors/remip/ReMIPClient.ts
@@ -63,6 +63,7 @@ export class ReMIPClient extends EventEmitter {
       return {
         objectiveValue: rawSolution.objective_value,
         variableValues: rawSolution.variables,
+        status: rawSolution.status || 'optimal', // デフォルトはoptimal、ステータスが提供されていない場合
       };
     }
     return null;
@@ -123,6 +124,7 @@ export class ReMIPClient extends EventEmitter {
                   solution = {
                     objectiveValue: rawSolution.objective_value,
                     variableValues: rawSolution.variables,
+                    status: rawSolution.status || 'optimal', // デフォルトはoptimal、ステータスが提供されていない場合
                   };
                 }
                 break;

--- a/src/schemas/solutions.ts
+++ b/src/schemas/solutions.ts
@@ -60,8 +60,11 @@ export type RemipResult = z.infer<typeof remipResultSchema>;
 export type RemipEvent = z.infer<typeof remipEventSchema>;
 
 export const solutionSchema = z.object({
-  objectiveValue: z.number(),
+  objectiveValue: z.number().nullable(),
   variableValues: z.record(z.string(), z.number()),
+  status: z
+    .enum(['not solved', 'optimal', 'infeasible', 'unbounded', 'timelimit'])
+    .optional(),
 });
 
 export type Solution = z.infer<typeof solutionSchema>;

--- a/src/tools/solveProblem.ts
+++ b/src/tools/solveProblem.ts
@@ -104,7 +104,7 @@ json.dumps(result)
     const solutionId = `sol-${randomUUID()}`;
     const solution: SolutionObject = {
       solution_id: solutionId,
-      status: 'optimal',
+      status: solutionResult.status || 'optimal', // ReMIPクライアントから返されるステータスを使用
       objective_value: solutionResult.objectiveValue,
       solve_time_seconds: solveTime,
       variables: solutionResult.variableValues,

--- a/tests/tools/solveProblem.test.ts
+++ b/tests/tools/solveProblem.test.ts
@@ -26,6 +26,7 @@ describe('solveProblem Tool', () => {
     solve: jest.fn().mockResolvedValue({
       objectiveValue: 123,
       variableValues: { x: 1 },
+      status: 'optimal',
     } as Solution),
   } as unknown as ReMIPClient;
 
@@ -51,5 +52,126 @@ describe('solveProblem Tool', () => {
     const executedCode = (fakePyodideRunner.run as jest.Mock).mock.calls[0][1];
     expect(executedCode).toContain('x = 1'); // User code
     expect(executedCode).toContain('isinstance(v, pulp.LpProblem)'); // Discovery code
+  });
+
+  it('should handle infeasible solutions correctly', async () => {
+    const fakeStorage = new StorageService();
+    fakeStorage.setModel(sessionId, model);
+
+    const discoveryResult = { problem: mockProblem, error: null };
+    const fakePyodideRunner = {
+      run: jest.fn().mockResolvedValue(JSON.stringify(discoveryResult)),
+    } as unknown as PyodideRunner;
+
+    // infeasibleなソリューションを返すReMIPクライアント
+    const infeasibleRemipClient = {
+      solve: jest.fn().mockResolvedValue({
+        objectiveValue: 0,
+        variableValues: {},
+        status: 'infeasible',
+      } as Solution),
+    } as unknown as ReMIPClient;
+
+    const params = { model_name: 'my_model', data: {} };
+
+    const result = await solveProblem(sessionId, params, {
+      storageService: fakeStorage,
+      pyodideRunner: fakePyodideRunner,
+      remipClient: infeasibleRemipClient,
+      sendNotification: async () => {},
+    });
+
+    expect(result.status).toBe('infeasible');
+    expect(result.objective_value).toBe(0);
+  });
+
+  it('should handle unbounded solutions correctly', async () => {
+    const fakeStorage = new StorageService();
+    fakeStorage.setModel(sessionId, model);
+
+    const discoveryResult = { problem: mockProblem, error: null };
+    const fakePyodideRunner = {
+      run: jest.fn().mockResolvedValue(JSON.stringify(discoveryResult)),
+    } as unknown as PyodideRunner;
+
+    const unboundedRemipClient = {
+      solve: jest.fn().mockResolvedValue({
+        objectiveValue: Infinity,
+        variableValues: {},
+        status: 'unbounded',
+      } as Solution),
+    } as unknown as ReMIPClient;
+
+    const params = { model_name: 'my_model', data: {} };
+
+    const result = await solveProblem(sessionId, params, {
+      storageService: fakeStorage,
+      pyodideRunner: fakePyodideRunner,
+      remipClient: unboundedRemipClient,
+      sendNotification: async () => {},
+    });
+
+    expect(result.status).toBe('unbounded');
+    expect(result.objective_value).toBe(Infinity);
+  });
+
+  it('should handle timelimit solutions correctly', async () => {
+    const fakeStorage = new StorageService();
+    fakeStorage.setModel(sessionId, model);
+
+    const discoveryResult = { problem: mockProblem, error: null };
+    const fakePyodideRunner = {
+      run: jest.fn().mockResolvedValue(JSON.stringify(discoveryResult)),
+    } as unknown as PyodideRunner;
+
+    const timelimitRemipClient = {
+      solve: jest.fn().mockResolvedValue({
+        objectiveValue: 100,
+        variableValues: { x: 5 },
+        status: 'timelimit',
+      } as Solution),
+    } as unknown as ReMIPClient;
+
+    const params = { model_name: 'my_model', data: {} };
+
+    const result = await solveProblem(sessionId, params, {
+      storageService: fakeStorage,
+      pyodideRunner: fakePyodideRunner,
+      remipClient: timelimitRemipClient,
+      sendNotification: async () => {},
+    });
+
+    expect(result.status).toBe('timelimit');
+    expect(result.objective_value).toBe(100);
+  });
+
+  it('should handle not solved solutions correctly', async () => {
+    const fakeStorage = new StorageService();
+    fakeStorage.setModel(sessionId, model);
+
+    const discoveryResult = { problem: mockProblem, error: null };
+    const fakePyodideRunner = {
+      run: jest.fn().mockResolvedValue(JSON.stringify(discoveryResult)),
+    } as unknown as PyodideRunner;
+
+    const notSolvedRemipClient = {
+      solve: jest.fn().mockResolvedValue({
+        objectiveValue: null,
+        variableValues: {},
+        status: 'not solved',
+      } as Solution),
+    } as unknown as ReMIPClient;
+
+    const params = { model_name: 'my_model', data: {} };
+
+    const result = await solveProblem(sessionId, params, {
+      storageService: fakeStorage,
+      pyodideRunner: fakePyodideRunner,
+      remipClient: notSolvedRemipClient,
+      sendNotification: async () => {},
+    });
+
+    expect(result.status).toBe('not solved');
+    expect(result.objective_value).toBe(null);
   });
 });


### PR DESCRIPTION
## Problem

The `solve_problem` function was always returning `optimal` status even for infeasible problems.

## Root Cause

- `status: 'optimal'` was hardcoded in `solveProblem.ts` line 107
- The `Solution` type returned by ReMIP client didn't include status information

## Solution

### 1. Extended Solution Type
- Added `status` field to `Solution` type (optional)
- Changed `objectiveValue` to `nullable()` to handle unbounded/not solved cases

### 2. Updated ReMIP Client
- Properly handle `rawSolution.status` in both non-streaming and streaming response processing
- Use `'optimal'` as default when status is not provided

### 3. Fixed solveProblem
- Replaced hardcoded `status: 'optimal'` with `solutionResult.status || 'optimal'`
- Now properly uses status information from ReMIP client

### 4. Added Comprehensive Tests
- Added test cases for all LpStatus values (optimal, infeasible, unbounded, timelimit, not solved)
- Updated existing tests to work with new `Solution` type

## Verification

✅ All tests pass
✅ Infeasible solutions correctly return `status: 'infeasible'`
✅ Other statuses (unbounded, timelimit, not solved) are handled correctly

## Files Changed

- `src/schemas/solutions.ts` - Solution type definition changes
- `src/connectors/remip/ReMIPClient.ts` - Added status information processing
- `src/tools/solveProblem.ts` - Fixed hardcoded status
- `tests/tools/solveProblem.test.ts` - Added comprehensive test cases

Now the actual status returned by the ReMIP server is properly reflected in the solution.