### PR TITLE
fix(storage): Ensure listSolutions returns only summary fields

### DIFF
--- a/src/app/storage.ts
+++ b/src/app/storage.ts
@@ -53,9 +53,12 @@ export class StorageService {
   public listSolutions(sessionId: string): SolutionSummary[] {
     const sessionSolutions = this.getSolutionsForSession(sessionId);
     return Array.from(sessionSolutions.values()).map((solution) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { variables, ...summary } = solution;
-      return summary;
+      return {
+        solution_id: solution.solution_id,
+        status: solution.status,
+        objective_value: solution.objective_value,
+        solve_time_seconds: solution.solve_time_seconds,
+      };
     });
   }
 

--- a/tests/tools/auxiliaryTools.test.ts
+++ b/tests/tools/auxiliaryTools.test.ts
@@ -53,10 +53,41 @@ describe('Auxiliary Tools', () => {
   });
 
   describe('listSolutions', () => {
-    it('should return a list of all solution summaries', async () => {
+    it('should return only summary fields, stripping all extra details', async () => {
+      // Arrange: Create a full solution object with all possible fields.
+      const fullSolution: SolutionObject = {
+        solution_id: 's1',
+        status: 'optimal',
+        objective_value: 1,
+        solve_time_seconds: 1,
+        // Add all extra fields that should be stripped
+        variables: { x: 1 },
+        mip_gap: 0.01,
+        slacks: { c1: 0 },
+        duals: { c1: 0.5 },
+        reduced_costs: { x: 0 },
+      };
+      // Re-initialize storage service to ensure a clean state for this specific test
+      storageService = new StorageService();
+      storageService.setSolution(sessionId, fullSolution);
+
+      // Act
       const result = await listSolutions(sessionId, {}, { storageService });
-      const { variables: _variables, ...summary } = solution1;
-      expect(result).toEqual([summary]);
+
+      // Assert
+      expect(result).toHaveLength(1);
+      const summary = result[0];
+
+      // Check that summary fields are present
+      expect(summary.solution_id).toBe('s1');
+      expect(summary.status).toBe('optimal');
+
+      // Check that extra fields are NOT present
+      expect(summary).not.toHaveProperty('variables');
+      expect(summary).not.toHaveProperty('mip_gap');
+      expect(summary).not.toHaveProperty('slacks');
+      expect(summary).not.toHaveProperty('duals');
+      expect(summary).not.toHaveProperty('reduced_costs');
     });
   });
 });


### PR DESCRIPTION
fix(storage): Ensure listSolutions returns only summary fields

Fixes a schema validation error where the `list_solutions` tool would fail because the underlying `StorageService.listSolutions` method was not correctly stripping all extra fields from the solution objects.

The previous implementation used object destructuring to remove the `variables` property but left other non-summary fields like `mip_gap` and `slacks`, causing a validation failure.

This change modifies `StorageService.listSolutions` to explicitly build a new summary object, ensuring only the four required fields are returned. The unit test for this function has also been enhanced to explicitly check for the absence of all non-summary fields.